### PR TITLE
Add dependencies status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A [Leiningen](https://github.com/technomancy/leiningen) plugin to check your pro
 dependencies and plugins.
 
 [![Build Status](https://travis-ci.org/xsc/lein-ancient.svg?branch=master)](https://travis-ci.org/xsc/lein-ancient)
+[![Dependencies Status](http://jarkeeper.com/xsc/lein-ancient/status.png)](http://jarkeeper.com/xsc/lein-ancient)
 [![endorse](https://api.coderwall.com/xsc/endorsecount.png)](https://coderwall.com/xsc)
 
 This plugin supersedes [lein-outdated](https://github.com/ato/lein-outdated) and uses metadata


### PR DESCRIPTION
Hi,

I fixed jarkeeper.com to work again on GitHub (added SSL certificate).
It's based on your ancient-clj library. What is your opinion on having such badge for this lein plugin?
