### PR TITLE
introduce `check-input` task

### DIFF
--- a/lein-ancient/src/leiningen/ancient.clj
+++ b/lein-ancient/src/leiningen/ancient.clj
@@ -5,7 +5,8 @@
              [upgrade :as u]
              [verbose :refer :all]]
             [leiningen.core.main :as main]
-            [jansi-clj.auto]))
+            [jansi-clj.auto]
+            [leiningen.ancient.utils :as utils]))
 
 
 (defn- as-deprecated
@@ -21,6 +22,7 @@
   ^:higher-order ^:no-project-needed
   ^{:subtasks [#'c/check
                #'c/check-profiles
+               #'c/check-stdin
                #'g/show-versions
                #'g/show-latest
                #'u/upgrade
@@ -33,10 +35,11 @@
     (case (first args)
       "check"                       (run c/check)
       "check-profiles"              (run c/check-profiles)
+      "check-input"                 (run c/check-stdin)
       "get"                         (run-deprecated "show-versions" g/show-versions)
       "profiles"                    (run-deprecated "check-profiles" c/check-profiles)
       "show-versions"               (run g/show-versions)
       ("show-latest" "latest")      (run g/show-latest)
       "upgrade"                     (run u/upgrade)
       "upgrade-profiles"            (run u/upgrade-profiles)
-      (apply c/check project args))))
+      (apply (if (utils/stream-available? System/in) c/check-stdin c/check) project args))))

--- a/lein-ancient/src/leiningen/ancient/artifact/files.clj
+++ b/lein-ancient/src/leiningen/ancient/artifact/files.clj
@@ -6,6 +6,7 @@
              [zip :as z]]
             [leiningen.ancient.verbose :refer :all]
             [potemkin :refer [defprotocol+]]
+            [rewrite-clj.node :as n]
             [clojure.java.io :as io]))
 
 ;; ## Protocol
@@ -122,6 +123,15 @@
      :read-fn       #(reader/read-profiles-map! % prefix)
      :zipper-fn     z/read-profiles-zipper!
      :check-post-fn #(drop-prefixes prefix %))))
+
+(defn virtual-file
+  "Create new `DependencyFile` value based on a data map"
+  [path data]
+  (assert (map? data))
+  (dependency-file
+    path
+    :read-fn (constantly data)
+    :zipper-fn (constantly (n/map-node data))))
 
 ;; ## Example
 


### PR DESCRIPTION
This task can be used to check arbitrary list of artifacts provided via
stdin. The check-input task will be used as default task if stdin is
available.

The rationale is to reuse version checking machinery of lein-ancient
while allowing more flexible control of input artifacts. Unfortunately
lein-ancient as of 0.6.10 does not evaluate leiningen's project.clj file.
It uses its own way how to read project.clj and interpret it. Probably
due to optional rewriting functionality which needs to understand the
project as data.

Consider this example:

```
(def some-lib-version 1.2.3)
(defproject my-project "X.Y.Z-SNAPSHOT"
  ...
  :dependencies [...
                 [some-company/some-lib ~some-lib-version]
                 ...]
  ...
```

This is a valid leiningen project file which evaluates
`some-company/some-lib`dependency as version `1.2.3`. Unfortunately
lein-ancient silently skips such artifact check because it sees
"~some-lib-version" which is not a valid version string. Of course the
code can be arbitrarily complex so it would not be a good solution to
teach lein-ancient to somehow handle this specific case.

With check-input task we can use `lein pprint` to extract evaluated
parts of project.clj and pass it into lein-ancient for checking only.

```
lein pprint :dependencies | lein ancient
```

Also note that some future release of lein pprint will support arbitrary
get-in paths[1], so that it will be convenient to extract multiple
lists from different parts of project.clj at once. The check-input task
is prepared for this and is able to read multiple EDN forms from input
and concatenate them into one list. Also lein pprint supports
with-profiles so it is flexible enough to extract list evaluated in the
context of selected profile(s).

[1] https://github.com/technomancy/leiningen/commit/c63301a56432c4398b5ff86dc73ccb18d0b32c61