### PR TITLE
Add java-agents check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ lein ancient
 ```
 
 You can specify the type of versions to check with `:allow-snapshots`, `:allow-qualified` and
-`:allow-all`, and the kind of artifacts with `:plugins` and `:all`:
+`:allow-all`, and the kind of artifacts with `:plugins`, `:java-agents`, and `:all`:
 
 ```bash
 $ lein ancient :allow-snapshots
@@ -50,6 +50,9 @@ $ lein ancient :allow-snapshots
 $ lein ancient :plugins
 [lein-midje "3.1.2"] is available but we use "3.0.1"
 ```
+
+$ lein ancient :java-agents
+[com.newrelic.agent.java/newrelic-agent "3.43.0"] is available but we use "3.35.1"
 
 It works recursively, too:
 

--- a/lein-ancient/src/leiningen/ancient/artifact/check.clj
+++ b/lein-ancient/src/leiningen/ancient/artifact/check.clj
@@ -78,7 +78,7 @@
 
 (defn- collect-artifacts-from-map
   [options path artifacts]
-  (for [k [:dependencies :managed-dependencies :plugins :profiles]
+  (for [k [:dependencies :managed-dependencies :plugins :profiles :java-agents]
         :when (contains? artifacts k)
         :let [data (get artifacts k)]
         :when (collect-from? k data)

--- a/lein-ancient/src/leiningen/ancient/artifact/options.clj
+++ b/lein-ancient/src/leiningen/ancient/artifact/options.clj
@@ -83,12 +83,14 @@
          :qualified? (boolean qualified?)))
 
 (defn- selector-options
-  [options {:keys [dependencies? plugins? profiles? check-clojure? only exclude]
+  [options {:keys [dependencies? plugins? profiles? java-agents? check-clojure?
+                   only exclude]
             :or {dependencies? true, profiles? true}}]
-
-  (let [base (->> [dependencies? plugins? profiles? check-clojure?]
+  (let [base (->> [dependencies? plugins? profiles? java-agents?
+                   check-clojure?]
                   (map #(if % :include :exclude))
-                  (zipmap [:dependencies :plugins :profiles :clojure])
+                  (zipmap [:dependencies :plugins :profiles :java-agents
+                           :clojure])
                   (reduce
                     (fn [m [marker k]]
                       (update-in m [k] conj marker))

--- a/lein-ancient/src/leiningen/ancient/artifact/reader.clj
+++ b/lein-ancient/src/leiningen/ancient/artifact/reader.clj
@@ -22,7 +22,8 @@
     {:dependencies         (find-in-project root :dependencies [])
      :managed-dependencies (find-in-project root :managed-dependencies [])
      :plugins              (find-in-project root :plugins [])
-     :profiles             (find-in-project root :profiles {})}
+     :profiles             (find-in-project root :profiles {})
+     :java-agents          (find-in-project root :java-agents [])}
     (throw
       (Exception.
         (str "invalid project file: " path)))))
@@ -48,7 +49,8 @@
                       [:managed-dependencies
                        :dependencies
                        :plugins
-                       :profiles])]
+                       :profiles
+                       :java-agents])]
     (project/init-project
       (with-meta
         (merge old-project new-project)

--- a/lein-ancient/src/leiningen/ancient/cli.clj
+++ b/lein-ancient/src/leiningen/ancient/cli.clj
@@ -6,8 +6,8 @@
 
 (def ^:private flags
   "All available flags and effects."
-  {:all             [#{:dependencies? :plugins?}
-                     "check dependencies _and_ plugins."]
+  {:all             [#{:dependencies? :plugins? :java-agents?}
+                     "check dependencies, plugins, _and_ java-agents."]
    :allow-all       [#{:snapshots? :qualified?}
                      "allow SNAPSHOT and qualified versions to be reported as new."]
    :allow-snapshots [#{:snapshots?}
@@ -18,8 +18,10 @@
                      "include Clojure (org.clojure/clojure) when checking for outdated artifacts."]
    :interactive     [#{:interactive?}
                      "prompt the user for approval of any changes made during upgrade."]
-   :plugins         [#{:no-dependencies? :plugins?}
+   :plugins         [#{:no-dependencies? :no-java-agents? :plugins?}
                      "check _only_ plugins."]
+   :java-agents     [#{:no-dependencies? :no-plugins? :java-agents?}
+                     "check _only_ java-agents"]
    :no-colors       [#{:no-colors?}
                      "explicitly disable colorized output."]
    :no-colours      [#{:no-colors?}
@@ -111,6 +113,7 @@
          :exclude       []
          :dependencies? true
          :profiles?     true
+         :java-agents?  true
          :colors?       true
          :tests?        true})))
 

--- a/lein-ancient/src/leiningen/ancient/get.clj
+++ b/lein-ancient/src/leiningen/ancient/get.clj
@@ -59,7 +59,8 @@
    :fixed {:snapshots? true
            :qualified? true
            :dependencies? true
-           :plugins? true}}
+           :plugins? true
+           :java-agents? true}}
   [{:keys [artifact-opts args]}]
   (if-let [artifact' (first args)]
     (let [{:keys [symbol] :as artifact} (ancient/read-artifact artifact')]
@@ -77,7 +78,8 @@
    :exclude [:all :check-clojure :interactive :plugins
              :no-profiles :no-tests :tests :print :recursive]
    :fixed {:dependencies? true
-           :plugins? true}}
+           :plugins? true
+           :java-agents? true}}
   [{:keys [artifact-opts args]}]
   (if-let [artifact' (first args)]
     (let [{:keys [symbol] :as artifact} (ancient/read-artifact artifact')

--- a/lein-ancient/test/leiningen/ancient/cli_test.clj
+++ b/lein-ancient/test/leiningen/ancient/cli_test.clj
@@ -13,6 +13,7 @@
   :dependencies?    true
   :plugins?         false
   :profiles?        true
+  :java-agents?     true
   :qualified?       false
   :snapshots?       false
   :interactive?     false
@@ -40,7 +41,7 @@
       (with-out-str
         (with-logging true
           (parse [":get"])))
-        => #"no longer supported")
+      => #"no longer supported")
 
 (fact "about unapplicable flags."
       (with-out-str
@@ -68,15 +69,21 @@
             (dis flags ks) => (dis defaults ks)
             (select-keys flags ks) => ?effects))
     ?args                    ?effects
-    [":all"]                 {:dependencies? true, :plugins? true}
+    [":all"]                 {:dependencies? true, :plugins? true,
+                              :java-agents? true}
     [":allow-all"]           {:snapshots? true, :qualified? true}
     [":allow-snapshots"]     {:snapshots? true}
     [":allow-qualified"]     {:qualified? true}
     [":check-clojure"]       {:check-clojure? true}
     [":interactive"]         {:interactive? true}
-    [":plugins"]             {:dependencies? false, :plugins? true}
-    [":all" ":plugins"]      {:dependencies? true, :plugins? true}
-    [":plugins" ":all"]      {:dependencies? true, :plugins? true}
+    [":plugins"]             {:dependencies? false, :plugins? true,
+                              :java-agents? false}
+    [":all" ":plugins"]      {:dependencies? true, :plugins? true,
+                              :java-agents? true}
+    [":plugins" ":all"]      {:dependencies? true, :plugins? true,
+                              :java-agents? true}
+    [":java-agents"]         {:dependencies? false, :plugins? false,
+                              :java-agents? true}
     [":no-colors"]           {:colors? false}
     [":no-colours"]          {:colors? false}
     [":no-profiles"]         {:profiles? false}


### PR DESCRIPTION
We have the NewRelic agent in our `:java-agents` vector in many of our `project.clj` files. It is constantly getting out of date because lein-ancient can't currently check it.

This PR adds the ability to do that. It adds a `:java-agents` arg and turns that on under `check :all` as well.

The tests are updated and I have manually tested it with both `check` and `upgrade`. I also added a mention of the new option to the README.