### PR TITLE
allow region to be defined when using s3 repositories

### DIFF
--- a/ancient-clj/src/ancient_clj/io/s3.clj
+++ b/ancient-clj/src/ancient_clj/io/s3.clj
@@ -33,12 +33,11 @@
   [options]
   (check-credentials! options)
   (delay
-    (if (:username options)
-      (.. (AmazonS3ClientBuilder/standard)
-          (withCredentials
-            (static-credentials-provider options))
-          (build))
-      (AmazonS3ClientBuilder/defaultClient))))
+   (cond-> (AmazonS3ClientBuilder/standard)
+     (:username options) (.withCredentials
+                           (static-credentials-provider options))
+     (:region options)   (.withRegion (:region options))
+     true (.build))))
 
 (defn- s3-get-object!
   "Gets an S3 object at the given bucket and key.  The client-ref is a client

--- a/ancient-clj/test/ancient_clj/io/s3_test.clj
+++ b/ancient-clj/test/ancient_clj/io/s3_test.clj
@@ -12,6 +12,7 @@
 (def opts
   {:username   "abc"
    :passphrase "def"
+   :region     "ghi"
    :path       "snapshots"})
 
 ;; ## Tests


### PR DESCRIPTION
This PR is intended to make an option to define a specific region when using s3 based repositories.

Using the system default region can be a problem when you trying to access a bucket that is located in a different region than you `default_region`. A common error is the following:
`"The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'sa-east-1' (Service: Amazon S3; Status Code: 400; Error Code: AuthorizationHeaderMalformed; Request ID: xxx)"`

So now, it'll be able to create the `S3Client` based on the region specified in the repositories map, like:
```
{"my-s3-repo" {:url "s3p://my-bucket/releases"
               :username   "bla"
               :passphrase "bla"
               :region     "sa-east-1"}}
```
