### PR TITLE
Restores install instructions. Fixes #92.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ lein-ancient is destined for Leiningen >= 2.4.0.
 
 ## Usage
 
-```sh
-lein help ancient
-lein help ancient <subtask>
+Put the following into the `:plugins` vector of the `:user` profile in your `~/.lein/profiles.clj`:
+
+```clojure
+[lein-ancient "0.6.15"]
 ```
 
 ### Check Artifacts

--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@ lein-ancient is destined for Leiningen >= 2.4.0.
 
 ## Usage
 
-Put the following into the `:plugins` vector of the `:user` profile in your `~/.lein/profiles.clj`:
+Install `lein-ancient` by putting the following into the `:plugins` vector of the `:user` profile in your `~/.lein/profiles.clj`:
 
 ```clojure
 [lein-ancient "0.6.15"]
+```
+
+Once `lein-ancient` is installed,cd  use Leiningen's built-in help feature to see how to use it:
+
+``` bash
+lein help ancient
+lein help ancient <subtask>
 ```
 
 ### Check Artifacts


### PR DESCRIPTION
This PR restores a text-only version of the install instructions that existed prior to 19ea1caa9cde651b70344f5e577c866e7c8995b0. 

Only documentation was changed; all code remains the same.