### PR TITLE
Upgrade clj-http from 2.1.0 to 3.7.0 so ancient can work with SNI

### DIFF
--- a/ancient-clj/project.clj
+++ b/ancient-clj/project.clj
@@ -10,7 +10,7 @@
                  [version-clj "0.1.2"]
                  ;; Note that this is the samve version used by s3-wagon-private 1.3.0
                  [com.amazonaws/aws-java-sdk-s3 "1.11.28"]
-                 [clj-http "2.1.0"
+                 [clj-http "3.7.0"
                   :exclusions [com.cognitect/transit-clj
                                crouton
                                org.apache.httpcomponents/httpclient]]
@@ -20,7 +20,7 @@
   :scm {:dir ".."}
   :profiles {:dev {:dependencies [[midje "1.8.3"]
                                   [clj-time "0.11.0"]
-                                  [http-kit "2.1.19"]]
+                                  [http-kit "2.2.0"]]
                    :plugins [[lein-midje "3.1.3"]]}}
   :aliases {"test" ["midje"]}
   :pedantic? :abort)


### PR DESCRIPTION
Upgrade clj-http from 2.1.0 to 3.7.0 so ancient can work with SNI. Upgrade http-kit from 2.1.19 to 2.2.0 for bug fixes and stability. 