### PR TITLE
allow application/octet-stream content-type

### DIFF
--- a/ancient-clj/src/ancient_clj/io/http.clj
+++ b/ancient-clj/src/ancient_clj/io/http.clj
@@ -11,7 +11,7 @@
    504 "server timeout."})
 
 (def ^:private valid-content-types
-  #{"text/xml" "application/xml"})
+  #{"text/xml" "application/xml" "application/octet-stream"})
 
 (defn- base-opts
   []


### PR DESCRIPTION
clojars recently started failing on me with messages like:

```
(warn)  [clojars] - Δ  430ms - failure when checking cljs-http/cljs-http: java.lang.Exception: response content-type is not XML (#{"text/xml" "application/xml"}): application/octet-stream
```

I guess clojars moved onto amazon S3 or reconfigured their S3 settings.

For example this is what is currently returned on my machine:
```
> http https://repo.clojars.org/cljs-http/cljs-http/maven-metadata.xml
HTTP/1.1 200 OK
Accept-Ranges: bytes
Age: 3393
Connection: keep-alive
Content-Length: 2189
Content-Type: application/octet-stream
Date: Sat, 08 Feb 2020 19:32:48 GMT
ETag: "6d9d2fce462b807443f03aec050ea3c9"
Last-Modified: Sat, 01 Feb 2020 19:43:28 GMT
Server: AmazonS3
Via: 1.1 varnish
X-Cache: HIT
X-Cache-Hits: 1
X-Served-By: cache-fra19141-FRA
X-Timer: S1581190369.969778,VS0,VE1
x-amz-id-2: OmF6Y7TdId2AIipx4I+V8VuDoXQJa8qkm1Ma9e2FboAfOHraHLeZ04Kk7aWaM6mBMHQZiqTst7o=
x-amz-request-id: C1FF559059BBB2DA

<?xml version="1.0" encoding="UTF-8"?>
<metadata>
  <groupId>cljs-http</groupId>
  <artifactId>cljs-http</artifactId>
  <versioning>
    <release>0.1.46</release>
    <versions>
      <version>0.0.1-SNAPSHOT</version>
      <version>0.0.2-SNAPSHOT</version>
      <version>0.0.3</version>
      <version>0.0.4-SNAPSHOT</version>
      <version>0.0.4</version>
      <version>0.0.5</version>
      <version>0.0.6-SNAPSHOT</version>
      <version>0.0.7-SNAPSHOT</version>
      <version>0.0.7</version>
      <version>0.0.8</version>
      <version>0.0.9</version>
      <version>0.1.0</version>
      <version>0.1.1</version>
      <version>0.1.2</version>
      <version>0.1.3</version>
      <version>0.1.4</version>
      <version>0.1.5</version>
      <version>0.1.6</version>
      <version>0.1.7</version>
      <version>0.1.8</version>
      <version>0.1.9</version>
      <version>0.1.10</version>
      <version>0.1.11</version>
      <version>0.1.12</version>
      <version>0.1.13</version>
      <version>0.1.14</version>
      <version>0.1.15</version>
      <version>0.1.16</version>
      <version>0.1.17-SNAPSHOT</version>
      <version>0.1.17</version>
      <version>0.1.18</version>
      <version>0.1.19</version>
      <version>0.1.20</version>
      <version>0.1.21</version>
      <version>0.1.22</version>
      <version>0.1.23</version>
      <version>0.1.24</version>
      <version>0.1.25</version>
      <version>0.1.26</version>
      <version>0.1.27</version>
      <version>0.1.28</version>
      <version>0.1.29</version>
      <version>0.1.30</version>
      <version>0.1.31</version>
      <version>0.1.32</version>
      <version>0.1.33</version>
      <version>0.1.34</version>
      <version>0.1.35</version>
      <version>0.1.36</version>
      <version>0.1.37</version>
      <version>0.1.38</version>
      <version>0.1.39</version>
      <version>0.1.40</version>
      <version>0.1.41</version>
      <version>0.1.42</version>
      <version>0.1.43</version>
      <version>0.1.44</version>
      <version>0.1.45</version>
      <version>0.1.46</version>
    </versions>
    <lastUpdated>20190205130051</lastUpdated>
  </versioning>
</metadata>
```