### PR TITLE
Add Google Cloud Storage support

### DIFF
--- a/ancient-clj/project.clj
+++ b/ancient-clj/project.clj
@@ -1,6 +1,11 @@
 (defproject ancient-clj "inherited-from-parent"
   :description "Maven Version Utilities for Clojure"
-  :dependencies [[org.clojure/clojure "1.10.1" :scope "provided"]
+  :dependencies [[com.google.cloud/google-cloud-storage "1.90.0"
+                  :exclusions [com.fasterxml.jackson.core/jackson-core
+                               io.opencensus/opencensus-api
+                               org.apache.httpcomponents/httpclient]]
+                 [io.opencensus/opencensus-api "0.23.0"]
+                 [org.clojure/clojure "1.10.1" :scope "provided"]
                  [org.clojure/data.xml "0.2.0-alpha6"]
                  [version-clj "0.1.2"]
                  ;; Note that this is the samve version used by s3-wagon-private 1.3.0

--- a/ancient-clj/src/ancient_clj/io.clj
+++ b/ancient-clj/src/ancient_clj/io.clj
@@ -1,5 +1,6 @@
 (ns ancient-clj.io
   (:require [ancient-clj.io
+             [google-cloud-storage :refer [google-cloud-storage-loader]]
              [http :refer [http-loader]]
              [local :refer [local-loader]]
              [s3 :refer [s3-loader]]]
@@ -83,6 +84,16 @@
 (defmethod loader-for* nil
   [_]
   nil)
+
+(defmethod loader-for* :gs
+  [{:keys [^String uri] :as opts}]
+  {:pre [(re-matches #"gs://.*" uri)]}
+  (let [[bucket path] (some-> (re-find #"gs://(.*)" uri)
+                              ^String (second)
+                              (.split "/" 2))]
+    (assert (not (empty? bucket)))
+    (assert (not (empty? path)))
+    (google-cloud-storage-loader bucket (assoc opts :path path))))
 
 (defmethod loader-for* :http
   [{:keys [uri] :as opts}]

--- a/ancient-clj/src/ancient_clj/io/google_cloud_storage.clj
+++ b/ancient-clj/src/ancient_clj/io/google_cloud_storage.clj
@@ -1,0 +1,48 @@
+(ns ancient-clj.io.google-cloud-storage
+  (:require [ancient-clj.io.xml :as xml])
+  (:import [com.google.cloud.storage Blob$BlobSourceOption BlobId StorageException StorageOptions]))
+
+(def ^:private valid-content-types
+  #{"text/xml" "application/xml" "application/octet-stream"})
+
+(defn- build-client-delay
+  "Creates a client in delay, possibly using credentials given with the
+  options."
+  [options]
+  (delay (.getService (StorageOptions/getDefaultInstance))))
+
+(defn- get-object!
+  "Gets an Google Cloud Storage object at the given bucket and key. The
+  client-ref is a client which must be dereferenced to be
+  used (permitting lazy evaluation)."
+  [client-ref bucket key]
+  (when-let [blob (.get @client-ref (BlobId/of bucket key))]
+    {:content (.getContent blob (into-array Blob$BlobSourceOption []))
+     :content-type (.getContentType blob)}))
+
+(defn google-cloud-storage-loader
+  "Create version loader for a Google Cloud Storage repository."
+  [bucket & [{:keys [path]
+              :or {path "releases"}
+              :as options}]]
+  (let [client (build-client-delay options)
+        get! #(get-object! client bucket %)]
+    (fn [group id]
+      (try
+        (let [object-id (xml/metadata-uri path group id)
+              {:keys [content content-type]} (get! object-id)
+              content-type (and content-type (first (.split content-type ";")))]
+          (if content-type
+            (if (contains? valid-content-types content-type)
+              (if content
+                (xml/metadata-xml->versions (slurp content))
+                (Exception. "object content not found."))
+              (Exception.
+               (format "object's content-type is not XML (%s): %s"
+                       (pr-str valid-content-types)
+                       content-type)))
+            []))
+        (catch StorageException ex
+          (Exception. (format "[code=%d] %s" (.getCode ex) (.getMessage ex)) ex))
+        (catch Throwable ex
+          ex)))))

--- a/ancient-clj/test/ancient_clj/io/google_cloud_storage_test.clj
+++ b/ancient-clj/test/ancient_clj/io/google_cloud_storage_test.clj
@@ -1,0 +1,57 @@
+(ns ancient-clj.io.google-cloud-storage-test
+  (:require [midje.sweet :refer :all]
+            [ancient-clj.io
+             [google-cloud-storage :refer [google-cloud-storage-loader]]
+             [xml :refer [metadata-uri]]
+             [xml-test :as xml]])
+  (:import [com.google.cloud.storage StorageException]))
+
+;; ## Fixtures
+
+(def opts
+  {:path "snapshots"})
+
+;; ## Tests
+(against-background
+  [(#'ancient-clj.io.google-cloud-storage/get-object!
+     anything
+     "bucket"
+     (metadata-uri "snapshots" "group" "id"))
+   => {:content (.getBytes (xml/generate-xml) "UTF-8")
+       :content-type "text/xml"}]
+  (fact "about the Google Cloud Storage/XML version loader."
+        (let [loader (google-cloud-storage-loader "bucket" opts)
+              vs (set (loader "group" "id"))]
+          vs => (has every? string?)
+          (count vs) => (count xml/versions)
+          xml/snapshot-versions => (has every? vs)
+          xml/qualified-versions => (has every? vs)
+          xml/release-versions => (has every? vs))))
+
+(let [throwable? (fn [msg]
+                   (fn [t]
+                     (and (instance? Throwable t)
+                          (.contains (.getMessage t) msg))))]
+  (tabular
+    (against-background
+      [(#'ancient-clj.io.google-cloud-storage/get-object!
+         anything
+         "bucket"
+         (metadata-uri "snapshots" "group" "id"))
+       => ?object]
+      (fact "about Google Cloud Storage/XML version loader failures."
+            (let [loader (google-cloud-storage-loader "bucket" opts)]
+              (loader "group" "id") => ?check)))
+    ?object                          ?check
+    {}                               []
+    {:content-type "text/plain"}     (throwable? "content-type is not XML")
+    {:content-type "text/xml;a=b"}   (throwable? "content not found")
+    {:content-type "text/xml"}       (throwable? "content not found")
+    {:content (.getBytes "<not-xml>" "UTF-8")
+     :content-type "text/xml"}       (throwable? "Could not parse metadata XML"))
+  (fact "about handling Google Cloud Storage errors."
+        (with-redefs [ancient-clj.io.google-cloud-storage/get-object!
+                      (fn [& _]
+                        (throw (StorageException. 403 "InvalidAccessKey")))]
+          (let [loader (google-cloud-storage-loader "bucket" opts)]
+            (loader "group" "id") => (throwable? "[code=403] InvalidAccessKey")))))

--- a/ancient-clj/test/ancient_clj/io_test.clj
+++ b/ancient-clj/test/ancient_clj/io_test.clj
@@ -25,7 +25,9 @@
   ;; uses default credentials
   "s3p://maven/bucket"
   {:uri "s3p://maven/bucket"}
-  {:uri "s3://maven/bucket"})
+  {:uri "s3://maven/bucket"}
+  {:uri "gs://bucket/maven/releases/" :no-auth true}
+  {:uri "gs://bucket/maven/releases/"})
 
 (tabular
   (fact "about invalid loader specifications."

--- a/lein-ancient/project.clj
+++ b/lein-ancient/project.clj
@@ -9,7 +9,7 @@
                  ^:source-dep [potemkin "0.4.5"]
                  ^:source-dep [version-clj "0.1.2"]
                  ^:source-dep [jansi-clj "0.1.1"]
-                 ^:source-dep [ancient-clj "0.7.0"
+                 ^:source-dep [ancient-clj "0.7.1-SNAPSHOT"
                                :exclusions [clj-http
                                             org.clojure/data.xml]]
 


### PR DESCRIPTION
Hello @xsc,

long time no see!

lein-ancient does not report about new dependencies in Maven repositories hosted on Google Cloud Storage, because there is no loader for it. Running lein-ancient on a project that uses lein-gcs-wagon [1] returns currently the following warning:

```
(warn)  [releases] could not create repository loader: {:url "gs://bucket/maven/releases/", :no-auth true}
(warn)  [snapshots] could not create repository loader: {:url "gs://bucket/maven/snapshots/", :no-auth true}
nothing to upgrade.
```

This PR add support for Google Cloud storage to lein-ancient.

Would you like to merge this?

Thanks, r0man.

[1] https://github.com/lupapiste/lein-gcs-wagon
